### PR TITLE
Pagination

### DIFF
--- a/DogBreeds/DogBreeds.xcodeproj/project.pbxproj
+++ b/DogBreeds/DogBreeds.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		CA74935E2AC719EF007F7485 /* SortOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA74935D2AC719EF007F7485 /* SortOrderViewModel.swift */; };
 		CA7493612AC71A6E007F7485 /* SortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7493602AC71A6E007F7485 /* SortOrder.swift */; };
 		CA7493632AC71D5C007F7485 /* DisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7493622AC71D5C007F7485 /* DisplayMode.swift */; };
+		CA7493652AC73A0B007F7485 /* FetchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7493642AC73A0B007F7485 /* FetchState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		CA74935D2AC719EF007F7485 /* SortOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortOrderViewModel.swift; sourceTree = "<group>"; };
 		CA7493602AC71A6E007F7485 /* SortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortOrder.swift; sourceTree = "<group>"; };
 		CA7493622AC71D5C007F7485 /* DisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMode.swift; sourceTree = "<group>"; };
+		CA7493642AC73A0B007F7485 /* FetchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -269,6 +271,7 @@
 			children = (
 				CA7493602AC71A6E007F7485 /* SortOrder.swift */,
 				CA7493622AC71D5C007F7485 /* DisplayMode.swift */,
+				CA7493642AC73A0B007F7485 /* FetchState.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				CA7493612AC71A6E007F7485 /* SortOrder.swift in Sources */,
 				CA237E572AC077B100BF5D16 /* ContentView.swift in Sources */,
 				CA237E9B2AC3517100BF5D16 /* GridView.swift in Sources */,
+				CA7493652AC73A0B007F7485 /* FetchState.swift in Sources */,
 				CA237E832AC07AE100BF5D16 /* DogAPIService.swift in Sources */,
 				CA237E552AC077B100BF5D16 /* DogBreedsApp.swift in Sources */,
 				CA237E952AC2FB0600BF5D16 /* ListViewCell.swift in Sources */,

--- a/DogBreeds/DogBreeds/Enums/DisplayMode.swift
+++ b/DogBreeds/DogBreeds/Enums/DisplayMode.swift
@@ -5,8 +5,6 @@
 //  Created by José João Pimenta Oliveira on 29/09/2023.
 //
 
-import Foundation
-
 enum DisplayMode {
     case list
     case grid

--- a/DogBreeds/DogBreeds/Enums/FetchState.swift
+++ b/DogBreeds/DogBreeds/Enums/FetchState.swift
@@ -1,0 +1,12 @@
+//
+//  FetchState.swift
+//  DogBreeds
+//
+//  Created by José João Pimenta Oliveira on 29/09/2023.
+//
+
+enum FetchState {
+    case loading
+    case fetched([DogBreed])
+    case error(Error)
+}

--- a/DogBreeds/DogBreeds/Services/DogAPIService.swift
+++ b/DogBreeds/DogBreeds/Services/DogAPIService.swift
@@ -64,12 +64,16 @@ class DogAPIService: DogAPIServiceProtocol {
         }
     }
 
-    func fetchDogBreeds(with order: SortOrder) async throws -> [DogBreed] {
+    func fetchDogBreeds(
+        with order: SortOrder,
+        page: Int
+    ) async throws -> [DogBreed] {
         let endpoint = "/v1/breeds"
         let parameters: [URLQueryItem] = [
-            URLQueryItem(name: "limit", value: "10"),
+            URLQueryItem(name: "limit", value: "20"),
             URLQueryItem(name: "has_breeds", value: "1"),
-            URLQueryItem(name: "order", value: order.rawValue)
+            URLQueryItem(name: "order", value: order.rawValue),
+            URLQueryItem(name: "page", value: "\(page)")
         ]
 
         do {

--- a/DogBreeds/DogBreeds/Services/DogAPIServiceProtocol.swift
+++ b/DogBreeds/DogBreeds/Services/DogAPIServiceProtocol.swift
@@ -11,7 +11,10 @@ protocol DogAPIServiceProtocol {
     var apiKey: String { get }
     var baseURL: URL? { get }
 
-    func fetchDogBreeds(with order: SortOrder) async throws -> [DogBreed]
+    func fetchDogBreeds(
+        with order: SortOrder,
+        page: Int
+    ) async throws -> [DogBreed]
     func fetchBreedImage(for imageID: String) async throws -> URL
 }
 

--- a/DogBreeds/DogBreeds/Services/MockDogAPIService.swift
+++ b/DogBreeds/DogBreeds/Services/MockDogAPIService.swift
@@ -13,7 +13,10 @@ class MockDogAPIService: DogAPIServiceProtocol {
     var didCallFetchDogsBreeds = false
     var didCallFetchBreedImage = false
 
-    func fetchDogBreeds(with order: SortOrder) async throws -> [DogBreed] {
+    func fetchDogBreeds(
+        with order: SortOrder,
+        page: Int
+    ) async throws -> [DogBreed] {
         didCallFetchDogsBreeds = true
 
         if let errorResponse {

--- a/DogBreeds/DogBreeds/ViewModels/MainViewViewModel.swift
+++ b/DogBreeds/DogBreeds/ViewModels/MainViewViewModel.swift
@@ -7,12 +7,6 @@
 
 import SwiftUI
 
-enum FetchState {
-    case loading
-    case fetched([DogBreed])
-    case error(Error)
-}
-
 @MainActor
 class MainViewViewModel: ObservableObject {
     @Published var fetchState: FetchState = .loading

--- a/DogBreeds/DogBreeds/ViewModels/MainViewViewModel.swift
+++ b/DogBreeds/DogBreeds/ViewModels/MainViewViewModel.swift
@@ -17,7 +17,7 @@ class MainViewViewModel: ObservableObject {
         self.apiService = apiService
     }
 
-    func fetchDogBreeds(with order: SortOrder) async {
+    func fetchInitialDogBreeds(with order: SortOrder) async {
         do {
             fetchState = .loading
             let breeds = try await apiService.fetchDogBreeds(with: order)
@@ -62,7 +62,7 @@ class MainViewViewModel: ObservableObject {
     func clearAndFetchBreeds(with order: SortOrder) async {
         Task {
             await clearBreeds()
-            await fetchDogBreeds(with: order)
+            await fetchInitialDogBreeds(with: order)
         }
     }
 
@@ -72,10 +72,10 @@ class MainViewViewModel: ObservableObject {
 
     func sortBreeds(
         _ breeds: [DogBreed],
-        sortOrder: SortOrder
+        order: SortOrder
     ) -> [DogBreed] {
         return breeds.sorted {
-            switch sortOrder {
+            switch order {
             case .ascending:
                 return $0.name?.caseInsensitiveCompare($1.name ?? "") == .orderedAscending
             case .descending:

--- a/DogBreeds/DogBreeds/Views/DetailsView/DetailsView.swift
+++ b/DogBreeds/DogBreeds/Views/DetailsView/DetailsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct DetailsView: View {
+    private let padding: CGFloat = 6.0
     let breed: DogBreed
 
     var body: some View {
@@ -26,10 +27,10 @@ struct DetailsView: View {
                         DetailsTextView(title: "History:", value: breed.history)
                         DetailsTextView(title: "Description:", value: breed.description)
                     }
-                    .frame(width: geometry.size.width)
+                    .frame(width: geometry.size.width - padding)
                 }
                 .scrollIndicators(.never)
-                .padding()
+                .padding(padding)
             }
             .navigationBarTitle(breed.name ?? "Unknown breed", displayMode: .inline)
         }

--- a/DogBreeds/DogBreeds/Views/MainView/GridView/GridView.swift
+++ b/DogBreeds/DogBreeds/Views/MainView/GridView/GridView.swift
@@ -8,8 +8,11 @@
 import SwiftUI
 
 struct GridView: View {
-    let breeds: [DogBreed]
     private let size: CGFloat = 150
+    
+    @ObservedObject var mainViewViewModel: MainViewViewModel
+    @ObservedObject var sortOrderViewModel: SortOrderViewModel
+    let breeds: [DogBreed]
 
     var body: some View {
         ScrollView {
@@ -20,6 +23,11 @@ struct GridView: View {
                 ForEach(breeds, id: \.id) { breed in
                     NavigationLink(destination: DetailsView(breed: breed)) {
                         GridViewCell(breed: breed)
+                            .task {
+                                if mainViewViewModel.shouldLoadNextPage(breed: breed) {
+                                    await mainViewViewModel.loadNextPage(with: sortOrderViewModel.sortOrder)
+                                }
+                            }
                     }
                 }
             }
@@ -29,5 +37,9 @@ struct GridView: View {
 }
 
 #Preview {
-    GridView(breeds: [])
+    GridView(
+        mainViewViewModel: MainViewViewModel(),
+        sortOrderViewModel: SortOrderViewModel(),
+        breeds: []
+    )
 }

--- a/DogBreeds/DogBreeds/Views/MainView/ListView/ListView.swift
+++ b/DogBreeds/DogBreeds/Views/MainView/ListView/ListView.swift
@@ -8,16 +8,28 @@
 import SwiftUI
 
 struct ListView: View {
+    @ObservedObject var mainViewViewModel: MainViewViewModel
+    @ObservedObject var sortOrderViewModel: SortOrderViewModel
     let breeds: [DogBreed]
+
     var body: some View {
         List(breeds, id: \.id) { breed in
             NavigationLink(destination: DetailsView(breed: breed)) {
                 ListViewCell(breed: breed)
+                    .task {
+                        if mainViewViewModel.shouldLoadNextPage(breed: breed) {
+                            await mainViewViewModel.loadNextPage(with: sortOrderViewModel.sortOrder)
+                        }
+                    }
             }
         }
     }
 }
 
 #Preview {
-    ListView(breeds: [])
+    ListView(
+        mainViewViewModel: MainViewViewModel(),
+        sortOrderViewModel: SortOrderViewModel(),
+        breeds: []
+    )
 }

--- a/DogBreeds/DogBreeds/Views/MainView/MainView.swift
+++ b/DogBreeds/DogBreeds/Views/MainView/MainView.swift
@@ -35,7 +35,9 @@ struct MainView: View {
             }
             .onAppear {
                 Task {
-                    await mainViewViewModel.fetchDogBreeds(with: sortOrderViewModel.sortOrder)
+                    if mainViewViewModel.sortedBreeds.isEmpty {
+                        await mainViewViewModel.fetchInitialDogBreeds(with: sortOrderViewModel.sortOrder)
+                    }
                 }
             }
             .navigationBarTitle("Dog Breeds", displayMode: .inline)

--- a/DogBreeds/DogBreeds/Views/MainView/MainView.swift
+++ b/DogBreeds/DogBreeds/Views/MainView/MainView.swift
@@ -24,9 +24,17 @@ struct MainView: View {
                     } else {
                         switch displayMode {
                         case .list:
-                            ListView(breeds: breeds)
+                            ListView(
+                                mainViewViewModel: mainViewViewModel,
+                                sortOrderViewModel: sortOrderViewModel,
+                                breeds: breeds
+                            )
                         case .grid:
-                            GridView(breeds: breeds)
+                            GridView(
+                                mainViewViewModel: mainViewViewModel,
+                                sortOrderViewModel: sortOrderViewModel,
+                                breeds: breeds
+                            )
                         }
                     }
                 case .error(let error):


### PR DESCRIPTION
- Renamed `fetchDogBreeds` to `fetchInitialDogBreeds` on `MainViewViewModel`
- Added new `URLQueryItem` (`page`)
- `DogAPIService` method `fetchDogBreeds`now receives `page` as a parameter
- Added new method responsible for incrementing the `page` and calling `apiService.fetchDogBreeds`
- Added new method responsible for checking if we should fetch a new page or not `func shouldLoadNextPage(breed:)`
- Updated `ListView` and `GridView`. They are now responsible for checking if the last `cell` is `visible` (by calling `shouldLoadNextPage(breed:)`
- Added validation to stop unneeded requests everytime the `MainView` appeared.
- Moved `enum FetchState` into correct folder
- Delete unneeded `import Foundation` on `enum DisplayMode`
- Fixed `padding` issue on `DetailsView` - Trailing margin had a minor offset difference
- Changed max `limit` of fetched elements from `10` to `20`